### PR TITLE
Correct CSS color regex. Run tests to validate CSS colors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Currently passing the canonical [test suite][canonical] for draft3 except for th
 * `optional/zeroTerminatedFloats`
 * `optional/format` (some of the regexes borrowed from [tdegrunt's validator](https://github.com/tdegrunt/jsonschema) aren't working for me)
   * validation of date-time strings
-  * validation of CSS colors
   * validation of host names
 
 

--- a/src/draft3/strings.coffee
+++ b/src/draft3/strings.coffee
@@ -38,7 +38,7 @@ module.exports =
       throw new Error "Invalid format_name for 'format'"
 
 
-# regexes below were derived from 
+# regexes below were derived from
 # https://github.com/tdegrunt/jsonschema
 #
 #Copyright (C) 2012-2013 Tom de Grunt <tom@degrunt.nl>
@@ -76,7 +76,7 @@ format_regexes =
 
   uri: /^[a-zA-Z][a-zA-Z0-9+-.]*:[^\s]*$/
 
-  color: /(#?([0-9A-Fa-f]{3,6})\b)|(aqua)|(black)|(blue)|(fuchsia)|(gray)|(green)|(lime)|(maroon)|(navy)|(olive)|(orange)|(purple)|(red)|(silver)|(teal)|(white)|(yellow)|(rgb\(\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*\))|(rgb\(\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*\))/
+  color: /^(((#[0-9A-Fa-f]{3,6}))|(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow)|(rgb\(\s*([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\s*,\s*([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\s*,\s*([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\s*\))|(rgb\(\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*\)))$/
 
   "host-name": /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/
 

--- a/test/draft3_test.coffee
+++ b/test/draft3_test.coffee
@@ -13,7 +13,6 @@ runner = new SuiteRunner "draft3",
     "optional/zeroTerminatedFloats": true
     "optional/format": [
       "validation of date-time strings"
-      "validation of CSS colors"
       "validation of host names"
     ]
 


### PR DESCRIPTION
Closes [issues/4](https://github.com/pandastrike/jsck/issues/4).
