### PR TITLE
Improve host-name regex and enable host-name tests. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ Currently passing the canonical [test suite][canonical] for draft3 except for th
 * `optional/format` (some of the regexes borrowed from [tdegrunt's validator](https://github.com/tdegrunt/jsonschema) aren't working for me)
   * validation of date-time strings
   * validation of CSS colors
-  * validation of host names
-
 
 ### Managing resolution scope with the "id" attribute
 
@@ -139,4 +137,3 @@ I find it difficult to believe JSV is actually that slow, so it's probably my fa
 [draft3_doc]:http://tools.ietf.org/html/draft-zyp-json-schema-03
 [draft3_impl]:https://github.com/json-schema/json-schema/tree/master/draft-03
 [canonical]:https://github.com/json-schema/JSON-Schema-Test-Suite
-

--- a/doc/README.template.md
+++ b/doc/README.template.md
@@ -43,9 +43,7 @@ Currently passing the canonical [test suite][canonical] for draft3 except for th
 * `optional/zeroTerminatedFloats`
 * `optional/format` (some of the regexes borrowed from [tdegrunt's validator](https://github.com/tdegrunt/jsonschema) aren't working for me)
   * validation of date-time strings
-  * validation of CSS colors
-  * validation of host names
-
+  * validation of CSS colors  
 
 ### Managing resolution scope with the "id" attribute
 
@@ -112,4 +110,3 @@ I find it difficult to believe JSV is actually that slow, so it's probably my fa
 [draft3_doc]:http://tools.ietf.org/html/draft-zyp-json-schema-03
 [draft3_impl]:https://github.com/json-schema/json-schema/tree/master/draft-03
 [canonical]:https://github.com/json-schema/JSON-Schema-Test-Suite
-

--- a/src/draft3/strings.coffee
+++ b/src/draft3/strings.coffee
@@ -78,7 +78,7 @@ format_regexes =
 
   color: /(#?([0-9A-Fa-f]{3,6})\b)|(aqua)|(black)|(blue)|(fuchsia)|(gray)|(green)|(lime)|(maroon)|(navy)|(olive)|(orange)|(purple)|(red)|(silver)|(teal)|(white)|(yellow)|(rgb\(\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*\))|(rgb\(\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*\))/
 
-  "host-name": /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/
+  "host-name": /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])){0,3}\.?)$/
 
   alpha: /^[a-zA-Z]+$/
 
@@ -90,4 +90,3 @@ format_regexes =
   style: /\s*(.+?):\s*([^;]+);?/g
 
   phone: /^\+(?:[0-9] ?){6,14}[0-9]$/
-

--- a/test/draft3_test.coffee
+++ b/test/draft3_test.coffee
@@ -14,12 +14,9 @@ runner = new SuiteRunner "draft3",
     "optional/format": [
       "validation of date-time strings"
       "validation of CSS colors"
-      "validation of host names"
     ]
 
 runner.test
   constructor: draft3
   attribute: attribute
   test_number: test_number
-
-


### PR DESCRIPTION
Improve host-name regx and enable host-name tests.  Host-name regex still does match a few invalid strings, having lengths of 255, 256, and 257 characters. Closes [issues/5](https://github.com/pandastrike/jsck/issues/5).
