### PR TITLE
jayschema benchmarks

### DIFF
--- a/benchmarks/validators.coffee
+++ b/benchmarks/validators.coffee
@@ -8,6 +8,7 @@ Benchmark = require "./benchmark.coffee"
 JSCK = require "../src/draft4"
 JSONSchema= require('jsonschema').Validator
 JSV = require("JSV").JSV
+JaySchema = require("jayschema")
 
 samples = 64
 
@@ -34,6 +35,12 @@ module.exports =
         for i in [1..repeats]
           result = validator.validate(valid_doc, schema).errors
 
+    jayschema = new Benchmark "jayschema: valid document", (bm) ->
+      bm.setup -> new JaySchema()
+      bm.measure (validator) ->
+        for i in [1..repeats]
+          result = validator.validate(valid_doc, schema)
+
     ## Only valid for draft3 ATM.
     #jsv_bm = new Benchmark "JSV: valid document", (bm) ->
       #bm.setup ->
@@ -43,7 +50,7 @@ module.exports =
         #for i in [1..repeats]
           #result = validator.validate(valid_doc).errors
 
-    results = Benchmark.compare [jsck, jsonschema], {samples}
+    results = Benchmark.compare [jsck, jsonschema, jayschema], {samples}
 
     console.log()
     for name, result of results

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "JSV": "~4.0.2",
+    "jayschema": "~0.3.1",
     "coffee-script": "~1.7",
     "glob": "~3.2.6",
     "jsonschema": "~1.0.0",


### PR DESCRIPTION
ok this is absurdly easy, maybe shouldn't even be a PR. especially since the `benchmark-draft-subdirs` changes how it works a tiny bit anyway. but, it works, and it's tidy, so why not.

also, verified that the approach in the jayschema docs does actually work for validating a schema in the first place.
