### PR TITLE
Fixes #72 add is-my-json-valid to benchmarks

### DIFF
--- a/benchmarks/draft4/validators.coffee
+++ b/benchmarks/draft4/validators.coffee
@@ -38,6 +38,17 @@ module.exports =
       else
         result
 
+  "is-my-json-valid":
+    setup: (schema) ->
+      require("is-my-json-valid")(schema)
+    validate: ({validator, schema, document}) ->
+      validator(document)
+    error: (result) ->
+      if result.length == 0
+        false
+      else
+        result
+
 
   ## Disabled because it refuses to accept one of our schemas
   #"jsonschema":

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "amanda": "~0.5.1",
     "coffee-script": "~1.7",
     "glob": "~3.2.6",
+    "is-my-json-valid": "^1.4.1",
     "jayschema": "~0.3.1",
     "json-gate": "~0.8.21",
     "jsonschema": "~1.0.0",


### PR DESCRIPTION
Sorry but is-my-json-valid is a lot faster than jsck. Take a look at the Repo. @mafintosh explains his technique.