### PR TITLE
add is-my-json-valid 2.0.2 to the benchmark

### DIFF
--- a/benchmarks/draft4/validators.coffee
+++ b/benchmarks/draft4/validators.coffee
@@ -39,6 +39,18 @@ module.exports =
         result
 
 
+  "is-my-json-valid":
+    setup: (schema) ->
+      require("is-my-json-valid")(schema)
+    validate: ({validator, schema, document}) ->
+      validator(document)
+    error: (result) ->
+      if result == true
+        false
+      else
+        validator.errors
+
+
   ## Disabled because it refuses to accept one of our schemas
   #"jsonschema":
     #setup: (schema) ->

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "amanda": "~0.5.1",
     "coffee-script": "~1.7",
     "glob": "~3.2.6",
+    "is-my-json-valid": "^2.0.2",
     "jayschema": "~0.3.1",
     "json-gate": "~0.8.21",
     "json-schema-tests": "^0.1.1",


### PR DESCRIPTION
(I noticed #73 added the error handler wrongly in the benchmark so I decided to fix that in a new pr)

Since [is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) 2.0.2 now passes the JSONSchema v4 test suite (except for remoteRef, unicode surrogate pairs in maxLength/minLength) this PR adds it to the benchmark.

On my macbook air the benchmark yields the following result (is-my-json-valid 2.0.2 is between 5x-10x faster than the 2nd fastest)

```
## Benchmarks for Draft 4

Schema: 'Event - Valid document'.  A simple schema, exercising very few attributes
Sample size: 64
Validations per sample: 1024

  JSCK
  Warming up: ................................
  Iterations: ................................................................

  tv4
  Warming up: ................................
  Iterations: ................................................................

  jayschema
  Warming up: ................................
  Iterations: ................................................................

  is-my-json-valid
  Warming up: ................................
  Iterations: ................................................................

  z-schema
  Warming up: ................................
  Iterations: ................................................................


  JSCK: validations/millisecond
  median: 209.557    max: 228.418    min: 123.642

  tv4: validations/millisecond
  median: 105.971    max: 121.356    min: 75.914

  jayschema: validations/millisecond
  median: 1.656    max: 2.016    min: 1.153

  is-my-json-valid: validations/millisecond
  median: 2144.503    max: 2566.416    min: 1083.598

  z-schema: validations/millisecond
  median: 111.937    max: 118.423    min: 67.466

Relative speeds:
is-my-json-valid : 1.000
JSCK : 10.234
z-schema : 19.158
tv4 : 20.237
jayschema : 1294.885


Schema: 'Configuration'.  A moderately complex schema with some nesting and value constraints
Sample size: 64
Validations per sample: 256

  JSCK
  Warming up: ................................
  Iterations: ................................................................

  tv4
  Warming up: ................................
  Iterations: ................................................................

  jayschema
  Warming up: ................................
  Iterations: ................................................................

  is-my-json-valid
  Warming up: ................................
  Iterations: ................................................................

  z-schema
  Warming up: ................................
  Iterations: ................................................................


  JSCK: validations/millisecond
  median: 116.417    max: 134.879    min: 81.789

  tv4: validations/millisecond
  median: 46.318    max: 50.137    min: 27.424

  jayschema: validations/millisecond
  median: 0.945    max: 1.096    min: 0.649

  is-my-json-valid: validations/millisecond
  median: 599.532    max: 1080.169    min: 212.272

  z-schema: validations/millisecond
  median: 44.195    max: 52.362    min: 23.178

Relative speeds:
is-my-json-valid : 1.000
JSCK : 5.150
tv4 : 12.944
z-schema : 13.566
jayschema : 634.276


Schema: 'Transaction'.
Sample size: 64
Validations per sample: 64

  JSCK
  Warming up: ................................
  Iterations: ................................................................

  tv4
  Warming up: ................................
  Iterations: ................................................................

  jayschema
  Warming up: ................................
  Iterations: ................................................................

  is-my-json-valid
  Warming up: ................................
  Iterations: ................................................................

  z-schema
  Warming up: ................................
  Iterations: ................................................................


  JSCK: validations/millisecond
  median: 11.221    max: 14.939    min: 5.365

  tv4: validations/millisecond
  median: 2.344    max: 3.25    min: 1.544

  jayschema: validations/millisecond
  median: 0.048    max: 0.049    min: 0.034

  is-my-json-valid: validations/millisecond
  median: 77.295    max: 103.393    min: 50.874

  z-schema: validations/millisecond
  median: 4.65    max: 5.018    min: 2.739

Relative speeds:
is-my-json-valid : 1.000
JSCK : 6.888
z-schema : 16.621
tv4 : 32.975
jayschema : 1600.178
```