### PR TITLE
Add themis to benchmarks

### DIFF
--- a/benchmarks/draft4/validators.coffee
+++ b/benchmarks/draft4/validators.coffee
@@ -24,7 +24,29 @@ module.exports =
       else
         result.error
 
+  "Themis[minimal]":
+    setup: (schema) ->
+      Themis = require('themis')
+      Themis.validator(schema, { enable_defaults: false, algorithm: 'none', errors: { messages: false, validator_value: false, schema: false } })
+    validate: ({validator, schema, document}) ->
+      validator(document, '0')
+    error: (result) ->
+      if result.valid == true
+        false
+      else
+        result.errors
 
+  "Themis":
+    setup: (schema) ->
+      Themis = require('themis')
+      Themis.validator(schema)
+    validate: ({validator, schema, document}) ->
+      validator(document, '0')
+    error: (result) ->
+      if result.valid == true
+        false
+      else
+        result.errors
 
   "jayschema":
     setup: (schema) ->
@@ -37,7 +59,6 @@ module.exports =
         false
       else
         result
-
 
   "is-my-json-valid":
     setup: (schema) ->

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "simple-http-server": "~0.1.8",
     "testify": "~0.2.11",
     "tv4": "~1.1.4",
-    "z-schema": "~3.1.2"
+    "z-schema": "~3.1.2",
+    "themis": "~1.1.5"
   },
   "repository": "git@github.com:pandastrike/jsck.git",
   "author": "Matthew King <matthew@pandastrike.com>",


### PR DESCRIPTION
Themis has several configuration options which can affect its performance. As such I've added 2 validators in the benchmarks. `Themis[minimal]` (minimum features enabled) and just `Themis` (full support for default values enabled).


Signed-off-by: Johny Jose <johny@playlyfe.com>