### PR TITLE
Make JSCK client-friendly by removing dynamic require statements

### DIFF
--- a/src/draft3.coffee
+++ b/src/draft3.coffee
@@ -1,12 +1,10 @@
 validator = require("./validator")
 
-modules = [
-  "logical"
-  "numeric"
-  "objects"
-  "strings"
-]
-
 module.exports = validator
   uri: "http://json-schema.org/draft-03/schema#"
-  mixins: (require "./draft3/#{name}" for name in modules)
+  mixins: [
+    require "./draft3/logical"
+    require "./draft3/numeric"
+    require "./draft3/objects"
+    require "./draft3/strings"
+  ]

--- a/src/draft4.coffee
+++ b/src/draft4.coffee
@@ -1,13 +1,11 @@
 validator = require("./validator")
 
-modules = [
-  "type"
-  "logical"
-  "numeric"
-  "objects"
-  "strings"
-]
-
 module.exports = validator
   uri: "http://json-schema.org/draft-04/schema#"
-  mixins: (require "./draft4/#{name}" for name in modules)
+  mixins: [
+    require "./draft4/type"
+    require "./draft4/logical"
+    require "./draft4/numeric"
+    require "./draft4/objects"
+    require "./draft4/strings"
+  ]

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,5 @@
-lazy_require = (path) -> get: (-> require( path )), enumerable: true
 
-Object.defineProperties module.exports,
-  draft3: lazy_require "./draft3"
-  draft4: lazy_require "./draft4"
+module.exports =
+  draft3: require "./draft3"
+  draft4: require "./draft4"
 

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -28,17 +28,16 @@ module.exports = ({uri, mixins}) ->
 
     SCHEMA_URI = uri
 
-    common_modules = [
-      "type"
-      "numeric"
-      "comparison"
-      "arrays"
-      "objects"
-      "strings"
-    ]
+    common_modules =
+      "type": require "./common/type"
+      "numeric": require "./common/numeric"
+      "comparison": require "./common/comparison"
+      "arrays": require "./common/arrays"
+      "objects": require "./common/objects"
+      "strings": require "./common/strings"
 
-    common = for name in common_modules
-      mixin = require "./common/#{name}"
+    common = for name of common_modules
+      mixin = common_modules[name]
       for name, method of mixin
         Validator.prototype[name] = method
 


### PR DESCRIPTION
JSCK is a great JSON schema validator, but at the moment, it cannot be included in a client application that is written in CommonJS and bundled with browserify (https://github.com/substack/node-browserify/issues/377).

Looking through the source, it appeared that the dynamic requires existed primarily for convenience; create an array of module names and then iterate over said array, requiring each module. These array iterations can be easily replaced with an array of static require statements.

The one impacting change in this pull request is the removal of the `lazy_require` getters in `src/index.coffee`. While this does mean that the modules for both draft specs are now always required when running this package in Node, I believe it's a small price to pay to make JSCK more easily useable in client applications. However, if the ability to lazily require the specs is important enough, it would be a simple matter to have two separate methods, one that creates a getter for `./draft3` and one for `./draft4`, keeping the static require statements intact.