### PR TITLE
allow draft4 validator to provide specific errors when anyOf or oneOf fail

### DIFF
--- a/src/draft4/logical.coffee
+++ b/src/draft4/logical.coffee
@@ -20,6 +20,7 @@ module.exports =
       answer = tests.some (test) =>
         temp = new runtime.constructor
           pointer: ""
+          error_pointer: runtime.pointer
           errors: []
         test(data, temp)
         if temp.items_tested && temp.items_tested > most_items_tested
@@ -82,6 +83,7 @@ module.exports =
       for test in tests
         temp = new runtime.constructor
           pointer: ""
+          error_pointer: runtime.pointer
           errors: []
         test(data, temp)
         if temp.errors.length == 0

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -9,14 +9,16 @@ module.exports =
   # Used during document validation.  Maintains a list of errors and the
   # JSON pointer for the section of the document.
   Runtime: class Runtime
-    constructor: ({@errors, @pointer, @tested_item}) ->
+    constructor: ({@errors, @pointer, @error_pointer, @tested_item}) ->
       @items_tested = 0
       @tested_item ?= => @items_tested++
+      @error_pointer ?= @pointer
 
     child: (token) ->
       new @constructor
         errors: @errors
         pointer: "#{@pointer}/#{token.toString()}"
+        error_pointer: "#{@error_pointer}/#{token.toString()}"
         tested_item: @tested_item
 
     error: (context, value) ->
@@ -26,7 +28,7 @@ module.exports =
           attribute: context._attribute
           definition: context.definition
         document:
-          pointer: @pointer
+          pointer: @error_pointer
           value: value
 
 

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -9,12 +9,15 @@ module.exports =
   # Used during document validation.  Maintains a list of errors and the
   # JSON pointer for the section of the document.
   Runtime: class Runtime
-    constructor: ({@errors, @pointer}) ->
+    constructor: ({@errors, @pointer, @tested_item}) ->
+      @items_tested = 0
+      @tested_item ?= => @items_tested++
 
     child: (token) ->
       new @constructor
         errors: @errors
         pointer: "#{@pointer}/#{token.toString()}"
+        tested_item: @tested_item
 
     error: (context, value) ->
       @errors.push

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -57,6 +57,7 @@ module.exports = ({schema_uri, mixins}) ->
       @uris = {}
       @media_types = {}
       @unresolved = {}
+      @options = {}
 
       @add(DEFINITIONS[SCHEMA_URI])
       for schema in schemas
@@ -64,6 +65,9 @@ module.exports = ({schema_uri, mixins}) ->
           throw "This validator doesn't support this JSON schema."
         @add(schema)
 
+    set_options: (args) ->
+      @options = args
+      return this
 
     add: (schema) ->
       # Clone the schema to prevent any user changes from affecting JSCK.
@@ -266,6 +270,7 @@ module.exports = ({schema_uri, mixins}) ->
 
       test_function = (data, runtime) ->
         return null if typeof(data) == "undefined"
+        runtime.tested_item()
         for test in tests
           test(data, runtime)
         null


### PR DESCRIPTION
Resolves #98 

By setting an option on the validator, we can allow JSCK to return more specific errors

var JSCK = require("jsck").draft4;
var validator = new JSCK(schema).set_options({ "closestMatch": true });

The heuristic it uses is the most number of tests exercised in validating the document.  This is most likely to be the intended schema.

Since the constructor is currently variadic, it seemed safest to provide the options-setting as an additional method.  This could be part of the constructor if the constructor's signature were to be modified.
