### PR TITLE
don't crash if a $ref to an empty schema is found

### DIFF
--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -242,7 +242,8 @@ module.exports = ({schema_uri, mixins}) ->
       if (uri = schema.$ref)?
         if @uris[uri]
           return (args...) =>
-            @uris[uri]._test(args...)
+            if @uris[uri]._test?
+              @uris[uri]._test(args...)
         uri = URI.resolve(scope, uri)
         if pointer.indexOf(uri) == 0
           # When the URI of a $ref is a substring of the present context's URI,


### PR DESCRIPTION
Fixes #97 

This is the simple solution, and seems to work and be safe